### PR TITLE
option for decoding javascript utf8 and string literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Simple JavaScript/ECMAScript object literal reader
 Only supports object literals wrapped in `var x = ...;` statements, so you
   might want to do `read_js_object('var x = %s;' % literal)` if it's in another format.
 
+If you pass in the keyword argument use_unicode it will decode utf8 as
+well as unicode code points into python unicode strings
+
 Basic constant folding on strings and numbers is done, e.g. "hi " + "there!" reduces to "hi there!",
 and 1+1 reduces to 2.
 


### PR DESCRIPTION
I did some work to convert at least basic \u1234 unicode code points to python's unicode string type. tested in 2.7, not sure what happens in python 3. It's disabled by default, so it should have no effect unless you pass in a keyword argument.
Sorry about the formatting changes. My editor seems to have added a few newlines
